### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
O [EditorConfig](http://editorconfig.org) define um styleguide básico para o desenvolvimento de um projeto, para tanto, os desenvolvedores devem instalar um [plugin](http://editorconfig.org/#download) em seu editor de texto (como listado no site, alguns editores/IDEs já possuem suporte nativo).